### PR TITLE
DEV-41994 Don't create collector device for Kubernetes Clusters

### DIFF
--- a/rest_collector.go
+++ b/rest_collector.go
@@ -91,7 +91,7 @@ type RestCollector struct {
 
 	UserPermission string `json:"userPermission,omitempty"`
 
-	NeedAutoCreateCollectorDevice bool `json:"needAutoCreateCollectorDevice,omitempty"`
+	NeedAutoCreateCollectorDevice bool `json:"needAutoCreateCollectorDevice"`
 
 	WatchdogUpdatedOn int64 `json:"watchdogUpdatedOn,omitempty"`
 


### PR DESCRIPTION
We remove the "omitempty" tag for the "NeedAutoCreateCollectorDevice" field of the "RestCollector".
In this way, "NeedAutoCreateCollectorDevice=false" will be sent by rest api